### PR TITLE
Fix freeze on invalid videos

### DIFF
--- a/ffmpeg_video_stream.cpp
+++ b/ffmpeg_video_stream.cpp
@@ -88,7 +88,6 @@ void FFmpegVideoStreamPlayback::update_internal(double p_delta) {
 		}
 	} else if (decoder->get_decoder_state() == VideoDecoder::DecoderState::END_OF_STREAM) {
 		playing = false;
-		return;
 	}
 
 	Ref<DecodedFrame> peek_frame = available_frames.size() > 0 ? available_frames[0] : nullptr;
@@ -217,13 +216,13 @@ void FFmpegVideoStreamPlayback::set_paused_internal(bool p_paused) {
 }
 
 void FFmpegVideoStreamPlayback::play_internal() {
-	if (!playing && decoder->get_decoder_state() == VideoDecoder::RUNNING) {
-		clear();
-		playback_position = 0;
-		decoder->seek(0, true);
-	} else {
-		stop_internal();
+	if (decoder->get_decoder_state() == VideoDecoder::FAULTED) {
+		playing = false;
+		return;
 	}
+	clear();
+	playback_position = 0;
+	decoder->seek(0, true);
 	playing = true;
 }
 


### PR DESCRIPTION
Despite the issue being closed, the program still freezes if an invalid video file is put in a videostreamplayer under the right circumstances. This fixes the issue consistently, at least in my tests.