### PR TITLE
Fix cutting off end of videos

### DIFF
--- a/ffmpeg_video_stream.cpp
+++ b/ffmpeg_video_stream.cpp
@@ -85,10 +85,9 @@ void FFmpegVideoStreamPlayback::update_internal(double p_delta) {
 		// if at the end of the stream but our playback enters a valid time region again, a seek operation is required to get the decoder back on track.
 		if (playback_position < decoder->get_last_decoded_frame_time()) {
 			seek_into_sync();
+		} else {
+			playing = false;
 		}
-	} else if (decoder->get_decoder_state() == VideoDecoder::DecoderState::END_OF_STREAM) {
-		playing = false;
-		return;
 	}
 
 	Ref<DecodedFrame> peek_frame = available_frames.size() > 0 ? available_frames[0] : nullptr;

--- a/video_decoder.cpp
+++ b/video_decoder.cpp
@@ -459,11 +459,7 @@ void VideoDecoder::_read_decoded_frames(AVFrame *p_received_frame) {
 				}
 			}
 			unwrapped_frame.resize(width * height * 4);
-			if (!image.is_valid()) {
-				image = Image::create_from_data(width, height, false, Image::FORMAT_RGBA8, unwrapped_frame);
-			} else {
-				image->set_data(width, height, false, Image::FORMAT_RGBA8, unwrapped_frame);
-			}
+			image = Image::create_from_data(width, height, false, Image::FORMAT_RGBA8, unwrapped_frame);
 		}
 #ifdef FFMPEG_MT_GPU_UPLOAD
 		Ref<ImageTexture> tex;


### PR DESCRIPTION
As is, the video stream ends prematurely whenever the back-end decoder reaches the end-of-stream, even though there's still several frames that haven't been displayed by the front-end. Fixing that issue, though, reveals another - the last batch of frames all get replaced by the final frame of the video instead of whatever frame they should be. Both of these issues are fixed in this PR - the `ffmpeg_video_stream.cpp` change makes playback only end when there are no more frames left to display, and the `video_decoder.cpp` change prevents frames from replacing each other when ffmpeg_video_stream hasn't copied them yet.