### PR TITLE
Fix resource loader not informing singleton what extensions it supports

### DIFF
--- a/video_stream_ffmpeg_loader.cpp
+++ b/video_stream_ffmpeg_loader.cpp
@@ -91,6 +91,10 @@ PackedStringArray VideoStreamFFMpegLoader::_get_recognized_extensions() const {
 	return recognized_extension_cache;
 }
 
+bool VideoStreamFFMpegLoader::_handles_type(const StringName &p_type) const {
+	return VideoStreamFFMpegLoader::handles_type_internal(p_type);
+}
+
 Variant VideoStreamFFMpegLoader::_load(const String &p_path, const String &p_original_path, bool p_use_sub_threads, int32_t p_cache_mode) const {
 	return load_internal(p_path, p_original_path, nullptr, p_use_sub_threads, nullptr, (CacheMode)p_cache_mode);
 }

--- a/video_stream_ffmpeg_loader.h
+++ b/video_stream_ffmpeg_loader.h
@@ -64,6 +64,7 @@ public:
 	STREAM_FUNC_REDIRECT_1_CONST(String, get_resource_type, const String &, p_path);
 #ifdef GDEXTENSION
 	virtual PackedStringArray _get_recognized_extensions() const override;
+	virtual bool _handles_type(const StringName &p_type) const override;
 	virtual Variant _load(const String &p_path, const String &p_original_path, bool p_use_sub_threads, int32_t p_cache_mode) const override;
 #else
 	virtual void get_recognized_extensions(List<String> *p_extensions) const override;


### PR DESCRIPTION
The ResourceFormatLoader for FFmpeg videos has an internal implementation for `handles_type`, but doesn't expose it to the engine (and therefore the engine won't import FFmpeg-supported videos unless an FFmpegVideoStream is created directly). This PR exposes the function to the engine so it works as intended.