### PR TITLE
Fix gpu yuv conversion on godot-stable

### DIFF
--- a/video_decoder.cpp
+++ b/video_decoder.cpp
@@ -156,10 +156,9 @@ Error VideoDecoder::recreate_codec_context() {
 
 	AVCodecParameters codec_params = *video_stream->codecpar;
 	// YUV conversion needs rendering device and Godot 4.3+
-	if (codec_params.format == AVPixelFormat::AV_PIX_FMT_YUV420P && 
-		RenderingServer::get_singleton()->get_rendering_device() && 
-		(uint32_t(Engine::get_singleton()->get_version_info().get("hex", 0x0)) >= 0x040300)
-	) {
+	if (codec_params.format == AVPixelFormat::AV_PIX_FMT_YUV420P &&
+			RenderingServer::get_singleton()->get_rendering_device() &&
+			(uint32_t(Engine::get_singleton()->get_version_info().get("hex", 0x0)) >= 0x040300)) {
 		frame_format = FFmpegFrameFormat::YUV420P;
 	} else {
 		frame_format = FFmpegFrameFormat::RGBA8;


### PR DESCRIPTION
With this fix GPU YUV conversion needs rendering device _and Godot 4.3+_

Fixes #23 

Tested on Godot-stable (4.2.2.stable.official.15073afe3) and Godot-latest (4.3.dev6.official.89850d553) on compat and forward+ renderers