### PR TITLE
Bug: platform_methods module wasn't importing when building on windows.

### DIFF
--- a/gdextension_build/glsl_builders.py
+++ b/gdextension_build/glsl_builders.py
@@ -1,5 +1,7 @@
 from typing import Optional, Iterable
 from platform_methods import subprocess_main
+import sys, os
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
 import os.path
 


### PR DESCRIPTION
platform_methods module wasn't importing when building on Windows which was causing a compilation error near the end of compiling the libgdffmpeg.windows.template_debug.x86_64 and libgdffmpeg.windows.template_release.x86_64 files.