### PR TITLE
Fix to silent & generic errors when loading videos with unsupported codecs

### DIFF
--- a/video_decoder.cpp
+++ b/video_decoder.cpp
@@ -124,14 +124,37 @@ void VideoDecoder::prepare_decoding() {
 	ERR_FAIL_COND_MSG(find_stream_info_result < 0, vformat("Error finding stream info: %s", ffmpeg_get_error_message(find_stream_info_result)));
 
 	int stream_index = av_find_best_stream(format_context, AVMEDIA_TYPE_VIDEO, -1, -1, (const AVCodec **)&codec, 0);
+
+	// The stream was found but FFmpeg has no decoder for its codec.
+	// Re-probe ignoring decoder availability so we can name the codec and try a fallback.
+	if (stream_index == AVERROR_DECODER_NOT_FOUND && format_context->video_codec == nullptr) {
+		int raw_stream_index = av_find_best_stream(format_context, AVMEDIA_TYPE_VIDEO, -1, -1, nullptr, 0);
+		if (raw_stream_index >= 0) {
+			const AVCodecID unsupported_id = format_context->streams[raw_stream_index]->codecpar->codec_id;
+			String fallback_name = _codec_id_to_preferred_decoder_name(unsupported_id);
+			if (!fallback_name.is_empty()) {
+				forced_video_codec = avcodec_find_decoder_by_name(fallback_name.utf8().get_data());
+				if (forced_video_codec != nullptr) {
+					print_line(vformat("No default decoder for '%s', retrying with '%s'.",
+							avcodec_get_name(unsupported_id), fallback_name));
+					avformat_close_input(&format_context);
+					prepare_decoding();
+					return;
+				}
+			}
+			ERR_FAIL_MSG(vformat("No decoder found for '%s': codec not supported by this FFmpeg build.",
+					avcodec_get_name(unsupported_id)));
+		}
+	}
+
 	ERR_FAIL_COND_MSG(stream_index < 0, vformat("Couldn't find video stream: %s", ffmpeg_get_error_message(stream_index)));
 
 	{
 		if (format_context->video_codec == nullptr) {
 			const AVCodecID codec_id = format_context->streams[stream_index]->codecpar->codec_id;
-			String libvpx_decoder_name = _codec_id_to_libvpx(codec_id);
-			if (!libvpx_decoder_name.is_empty()) {
-				forced_video_codec = avcodec_find_decoder_by_name(libvpx_decoder_name.utf8().get_data());
+			String preferred_decoder_name = _codec_id_to_preferred_decoder_name(codec_id);
+			if (!preferred_decoder_name.is_empty()) {
+				forced_video_codec = avcodec_find_decoder_by_name(preferred_decoder_name.utf8().get_data());
 				if (forced_video_codec != nullptr) {
 					avformat_close_input(&format_context);
 					prepare_decoding();
@@ -638,19 +661,24 @@ AVFrame *VideoDecoder::_ensure_frame_audio_format(AVFrame *p_frame, AVSampleForm
 	return out_frame;
 }
 
-String VideoDecoder::_codec_id_to_libvpx(AVCodecID p_codec_id) const {
-	String out;
+String VideoDecoder::_codec_id_to_preferred_decoder_name(AVCodecID p_codec_id) const {
 	switch (p_codec_id) {
 		case AVCodecID::AV_CODEC_ID_VP8: {
-			out = "libvpx";
+			return "libvpx";
 		} break;
 		case AVCodecID::AV_CODEC_ID_VP9: {
-			out = "libvpx-vp9";
-		}
+			return "libvpx-vp9";
+		} break;
+		case AVCodecID::AV_CODEC_ID_HEVC: {
+			return "hevc";
+		} break;
+		case AVCodecID::AV_CODEC_ID_AV1: {
+			return "libaom-av1";
+		} break;
 		default: {
 		} break;
 	}
-	return out;
+	return String();
 }
 
 void VideoDecoder::seek(double p_time, bool p_wait) {

--- a/video_decoder.h
+++ b/video_decoder.h
@@ -191,7 +191,7 @@ private:
 	Ref<FFmpegFrame> _ensure_frame_pixel_format(Ref<FFmpegFrame> p_frame, AVPixelFormat p_target_pixel_format);
 	Ref<DecodedFrame> _unwrap_yuv_frame(double p_frame_time, Ref<FFmpegFrame> p_frame, FFmpegFrameFormat p_out_format);
 	AVFrame *_ensure_frame_audio_format(AVFrame *p_frame, AVSampleFormat p_target_audio_format);
-	String _codec_id_to_libvpx(AVCodecID p_codec_id) const;
+	String _codec_id_to_preferred_decoder_name(AVCodecID p_codec_id) const;
 
 public:
 	struct AvailableDecoderInfo {


### PR DESCRIPTION
Currently when `av_find_best_stream` returns `AVERROR_DECODER_NOT_FOUND`, the container is parsed and the stream exists. The codec is just not registered in this FFmpeg build.

The old code treated this the same as a missing stream. It fell through to `"Couldn't find video stream: Decoder not found"`, with no hint about which codec is the problem. The playback object returned null and `VideoStreamPlayer` failed silently.

### Changes
- Adds a dedicated `AVERROR_DECODER_NOT_FOUND` handler in `prepare_decoding()`. It re-probes ignoring decoder availability, names the codec, and tries a named fallback before failing.
- Renames `_codec_id_to_libvpx` to `_codec_id_to_preferred_decoder_name` since the function now covers more than VP8/VP9.
- Extends the fallback table with `AV_CODEC_ID_HEVC` (`"hevc"`) and `AV_CODEC_ID_AV1` (`"libaom-av1"`). If a future build includes those decoders, the plugin picks them up with no code change.
- The error now names the codec instead of giving a generic message.

### Before
These is how errors were shown, for reference:

`Couldn't find video stream: Decoder not found`
`Plugin returned null playback`

### After (unsupported codec, no fallback available)
Example to how errors are shown now:

`No decoder found for 'hevc': codec not supported by this FFmpeg build.`

### After (supported named decoder found)

`No default decoder for 'vp9', retrying with 'libvpx-vp9'.`

With these changes, now my .mp4 videos that were NOT being played.
I used this export properties on Davinci Resolve
<img width="438" height="351" alt="image" src="https://github.com/user-attachments/assets/ee0dbcd2-ccf1-4942-9b50-065c649df76b" />

Info about the videos after Davinci:
[video.txt](https://github.com/user-attachments/files/25727575/video.txt)

Info about the videos after I used Handbrake to compress them further:
[videohb.txt](https://github.com/user-attachments/files/25727576/videohb.txt)
(all information taken from MediaInfo).

I was getting these errors before:

```
E 0:00:07:010   scene_loader.gd:184 @ _fade_in(): Couldn't find video stream: Decoder not found
  <C++ Error>   Condition "stream_index < 0" is true.
  <C++ Source>  D:\a\EIRTeam.FFmpeg\EIRTeam.FFmpeg\video_decoder.cpp:127 @ VideoDecoder::prepare_decoding()
  <Stack Trace> scene_loader.gd:184 @ _fade_in()
                scene_loader.gd:319 @ load_scene()
                intro.gd:45 @ <anonymous lambda>()


E 0:00:07:010   scene_loader.gd:184 @ _fade_in(): Plugin returned null playback
  <C++ Error>   Condition "ret.is_null()" is true. Returning: nullptr
  <C++ Source>  scene/resources/video_stream.cpp:161 @ instantiate_playback()
  <Stack Trace> scene_loader.gd:184 @ _fade_in()
                scene_loader.gd:319 @ load_scene()
                intro.gd:45 @ <anonymous lambda>()
```


Now everything runs perfectly, with the same videos.


Hope it helps, as it helped me. If you find ANY issues, please let me know, so I can fix them ASAP.
Thanks for your time and for this amazing plugin!
😄 